### PR TITLE
chore: additional `package.json` metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
   },
   "author": "rixo <rixo@rixo.fr>",
   "license": "ISC",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/rixo/test-hmr"
-	},
-	"homepage": "https://github.com/rixo/test-hmr",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rixo/test-hmr"
+  },
+  "homepage": "https://github.com/rixo/test-hmr",
   "dependencies": {
     "esm": "^3.2.25",
     "find-up": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,11 @@
   },
   "author": "rixo <rixo@rixo.fr>",
   "license": "ISC",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/rixo/test-hmr"
+	},
+	"homepage": "https://github.com/rixo/test-hmr",
   "dependencies": {
     "esm": "^3.2.25",
     "find-up": "^5.0.0",


### PR DESCRIPTION
https://www.npmjs.com/package/test-hmr doesn't link to this repo, which can make it a bit tricky to find